### PR TITLE
feat(P0/TDD): Fundamentals & News integration + features merge; 10 tests passing

### DIFF
--- a/src/tools/fundamentals.py
+++ b/src/tools/fundamentals.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+import pandas as pd
+
+
+@dataclass
+class FundamentalsClient:
+    """Fundamentals via yfinance/yahooquery (MVP: 実装容易性重視の薄いラッパ)。
+    本番では安定APIに差し替え可能なIFを維持する。
+    """
+
+    def _fetch(self, tickers: List[str], fields: List[str]) -> pd.DataFrame:
+        # MVP: yfinance の info/sustainability 等はレート・安定性の問題があるため、
+        # 将来 yahooquery などに差し替える前提の仮実装とする。
+        import yfinance as yf
+        rows = []
+        for t in tickers:
+            try:
+                tk = yf.Ticker(t)
+                info = tk.get_info() if hasattr(tk, "get_info") else getattr(tk, "info", {})
+            except Exception:
+                info = {}
+            row = {"ticker": t}
+            for f in fields:
+                row[f] = info.get(f) if isinstance(info, dict) else None
+            rows.append(row)
+        return pd.DataFrame(rows)
+
+    def get_fundamentals(self, tickers: List[str], fields: List[str]) -> pd.DataFrame:
+        df = self._fetch(tickers, fields)
+        if "ticker" not in df.columns:
+            df.insert(0, "ticker", tickers)
+        return df
+
+

--- a/src/tools/news.py
+++ b/src/tools/news.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import List, Dict
+
+
+@dataclass
+class NewsClient:
+    """ニュース取得の薄いIF。MVPはモック/将来はRSS/API連携。
+    戻り値: list[dict(ticker,title,url,date)]
+    """
+
+    def _fetch(self, tickers: List[str], since: date) -> List[Dict]:
+        # MVP: 上位でモンキーパッチ/差し替え前提
+        return []
+
+    def get_news(self, tickers: List[str], since: date) -> List[Dict]:
+        return self._fetch(tickers, since)
+
+

--- a/tests/unit/test_fundamentals_tool.py
+++ b/tests/unit/test_fundamentals_tool.py
@@ -1,0 +1,19 @@
+from src.tools.fundamentals import FundamentalsClient
+
+
+def test_fundamentals_returns_dataframe_with_requested_fields(monkeypatch):
+    client = FundamentalsClient()
+
+    def mock_fetch(tickers, fields):
+        import pandas as pd
+        return pd.DataFrame({
+            "ticker": tickers,
+            fields[0]: [1.0] * len(tickers),
+            fields[1]: [2.0] * len(tickers),
+        })
+
+    monkeypatch.setattr(client, "_fetch", mock_fetch)
+    df = client.get_fundamentals(["AAPL", "MSFT"], ["roic", "fcf_margin"])
+    assert set(df.columns) >= {"ticker", "roic", "fcf_margin"}
+    assert df.shape[0] == 2
+

--- a/tests/unit/test_news_tool.py
+++ b/tests/unit/test_news_tool.py
@@ -1,0 +1,18 @@
+from datetime import date, timedelta
+from src.tools.news import NewsClient
+
+
+def test_news_returns_list_of_items(monkeypatch):
+    client = NewsClient()
+
+    def mock_fetch(tickers, since):
+        return [
+            {"ticker": tickers[0], "title": "Earnings beat", "url": "https://example.com/a", "date": str(since)},
+            {"ticker": tickers[0], "title": "Guide raised", "url": "https://example.com/b", "date": str(since + timedelta(days=1))},
+        ]
+
+    monkeypatch.setattr(client, "_fetch", mock_fetch)
+    out = client.get_news(["AAPL"], date(2025, 8, 1))
+    assert isinstance(out, list) and len(out) >= 1
+    assert set(out[0].keys()) >= {"ticker", "title", "url", "date"}
+


### PR DESCRIPTION
Summary\n- Add FundamentalsClient (MVP) and NewsClient (MVP)\n- Integrate both into RegionAgent and extend features merge (fundamental & news)\n- Keep yfinance-based fundamentals as provisional; safe to swap to stable API later\n- All unit tests green (10 passed)\n\nChanges\n- src/tools/fundamentals.py\n- src/tools/news.py\n- src/scoring/features.py (merge_fundamentals, merge_news_signal)\n- src/agents/regions.py (wire fundamentals/news)\n- tests/unit/test_fundamentals_tool.py\n- tests/unit/test_news_tool.py\n\nNotes\n- TDD applied; future work: enhance data quality, rate-limit handling, and news sentiment aggregation.