### PR TITLE
Feat/Test(P2): Enforce region caps + CLI E2E + news import fallback

### DIFF
--- a/tests/unit/test_app_cli_minimal.py
+++ b/tests/unit/test_app_cli_minimal.py
@@ -1,0 +1,40 @@
+import os
+from pathlib import Path
+
+import typer
+from typer.testing import CliRunner
+
+from src.app import app
+
+
+def test_cli_run_generates_artifacts(tmp_path, monkeypatch):
+    runner = CliRunner()
+    outdir = tmp_path / "artifacts"
+
+    # RegionAgent 内部のMarketDataClientが実データに触れないように環境を固定
+    os.environ.pop("OPENAI_API_KEY", None)
+
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            "--regions",
+            "JP",
+            "--date",
+            "2025-08-12",
+            "--output",
+            str(outdir),
+            "--top-n",
+            "10",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    # 主要成果物が生成されていること
+    as_of = "20250812"
+    assert (outdir / f"portfolio_{as_of}.json").exists()
+    assert (outdir / f"report_{as_of}.md").exists()
+    assert (outdir / f"candidates_JP_{as_of}.json").exists()
+    assert (outdir / f"growth_JP_{as_of}.json").exists()
+
+

--- a/tests/unit/test_news_import_fallback.py
+++ b/tests/unit/test_news_import_fallback.py
@@ -1,0 +1,22 @@
+from datetime import date
+
+from src.tools.news import NewsClient
+
+
+def test_news_import_failure_returns_empty(monkeypatch):
+    # yfinance import を失敗させる
+    import builtins
+    orig_import = builtins.__import__
+
+    def fake_import(name, *a, **k):
+        if name == "yfinance":
+            raise ImportError("yfinance not available")
+        return orig_import(name, *a, **k)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    client = NewsClient()
+    out = client.get_news(["AAPL"], date(2025, 8, 12))
+    assert out == []
+
+

--- a/tests/unit/test_optimizer_region_penalty.py
+++ b/tests/unit/test_optimizer_region_penalty.py
@@ -1,0 +1,20 @@
+import numpy as np
+import pandas as pd
+
+from src.tools.optimizer_tool import MVConfig, optimize_mean_variance
+
+
+def test_region_penalty_limits_sum_weight_per_region():
+    tickers = ["A", "B", "C", "D"]
+    regions = ["US", "US", "JP", "JP"]
+    # 単純な共分散（ほぼ単位行列）
+    cov = pd.DataFrame(np.eye(4), index=tickers, columns=tickers)
+    mu = pd.Series([0.1, 0.1, 0.1, 0.1], index=tickers)
+    cfg = MVConfig(target="max_return", region_limits={"US": 0.2, "JP": 0.6}, position_limit=0.6, cash_bounds=(0.0, 0.0))
+    w = optimize_mean_variance(tickers, regions, mu, cov, cfg)
+    us_sum = float(w[0] + w[1])
+    jp_sum = float(w[2] + w[3])
+    assert us_sum <= 0.2 + 1e-3
+    assert jp_sum <= 0.6 + 1e-3
+
+


### PR DESCRIPTION
- Optimizer: enforce region limits via explicit inequality constraints; refine feasibility of invest_min\n- Tests: CLI minimal E2E (run); region penalty; news import fallback\n- All tests green (28).