### PR TITLE
feat: 成長スコアを有効化し、詳細表示を追加

### DIFF
--- a/doc/improvement-grock4_20250815.md
+++ b/doc/improvement-grock4_20250815.md
@@ -1,0 +1,132 @@
+## 改善提案（grock4, 2025-08-15）
+
+### 概要（ハイライト）
+- **最適化の拡張**: ユーザー指定のリスク許容度（`risk_aversion`）と目標ボラ（`target_vol`）を導入し、`MVConfig` と CLI で制御可能に。
+- **テスト網羅の強化**: 統合/E2E/CLI テストを追加し、非決定性の排除（乱数seed）と外部依存（yfinance/OpenAI/matplotlib）のモックを徹底。
+- **データ統合の深化**: `fundamentals`/`news` を実運用に耐える形で `features` に取り込み。ニュースは軽量感情スコアを標準化して利用。
+- **観測可能性・再現性**: 出力に実行設定（パラメータ、commit hash、データ期間）を記録。ログを構造化。
+- **DevEx/CI**: pre-commit（ruff/black/mypy）、GitHub Actions によるテスト・lint・ビルド、`.gitignore` 強化。
+
+---
+
+### 優先度付きロードマップ
+- P0（安全性・品質の底上げ）
+  - `optimizer_tool` に `risk_aversion`/`target_vol` を追加し、`agents/optimizer.py` と `app.run` から渡す。
+  - 失敗時フォールバックとバリデーション（非現実的 `target_vol`、負の `risk_aversion` など）。
+  - 乱数seedの固定、ログの構造化（json/tsv）。
+  - CLI/E2E 最小テスト（Typer `CliRunner`）。
+- P1（機能充実）
+  - `features.merge_fundamentals`/`merge_news_signal` の重みづけ改善と欠損ロバスト化（RobustScaler/分位クリップ）。
+  - `RiskAgent` のメトリクスをレポートへ明示出力（相関/ボラ/最大DDを表と図で）。
+  - `MacroAgent` のCSV駆動＋基本ヒューリスティクスを README に明文化。
+- P2（高度化）
+  - 最適化の選択肢追加（CVaR/Black-Litterman/回転抑制のターンオーバー制約）。
+  - バックテスト簡易枠組み（週次TE/ボラ/DDを artifacts に時系列蓄積）。
+
+---
+
+### 最適化（optimizer）
+- 目的関数・制約
+  - `MVConfig` に以下を追加: `risk_aversion: float = 0.0`, `target_vol: float | None = None`。
+  - 目的関数: 既定は `var`、`risk_aversion>0` で `var - risk_aversion * ret`、`target==max_return` は `-ret`。
+  - ボラ上限: `w' Σ w <= target_vol^2` を SLSQP の不等式制約に追加。
+  - 地域上限: 現状のペナルティ方式は維持しつつ、将来的に線形制約化も検討。
+- 数値安定性
+  - `if cfg.risk_aversion > 0 and mu is not None:` の明示化（falsy判定を避ける）。
+  - 最適化失敗時は `x0` を返却しつつ、ログへ `res.message` を出力。
+- パラメータバリデーション
+  - `risk_aversion >= 0`、`target_vol is None or target_vol>0`、`target in {min_vol,max_return}` を `__post_init__` で検証。
+- 出力の説明可能性
+  - `portfolio_*.json` に `notes` とともに、`target/risk_aversion/target_vol` をレポートのサマリーへ反映。
+- テスト（追加）
+  - `risk_aversion` 増加で期待リターンが非減少。
+  - `target_vol` 制約の遵守（不可達時でも安全に終了）。
+  - 地域上限ペナルティが効くケースの確認。
+
+---
+
+### リスク（risk_tool / RiskAgent）
+- `compute_returns` 方式の統一（`pct`/`log`）と選択肢の明記、`RiskAgent` の内部でメソッド指定を受け取れるよう拡張。
+- `risk_metrics` の戻り値に `portfolio_level`（等加重や最終ウェイトでの推定ボラ/DD）を拡張可能に。
+- 図出力の安定化（`matplotlib` が無ければ skip、tests は `importorskip`）。
+
+---
+
+### データ統合（marketdata/fundamentals/news → features）
+- `fundamentals`
+  - 欠損・ゼロ割りの安全化、`net_debt_to_ebitda` の分母0回避、単位系の明記。
+  - 将来の安定API移行を見越したIF固定（現状yfinanceの制約をドキュメント化）。
+- `news`
+  - タイトル軽量感情は [-1,1] → [0,1] へ線形写像済み。語彙表の拡充と否定語処理を TODO から仕様化。
+  - `since` フィルタの境界日付の扱いをテストで固定。
+- `features`
+  - テクニカル: 1/3/6/12ヶ月モメンタムの定義（営業日換算）と系列不足時の `NaN` 処理を明文化。
+  - 正規化: `normalize_features` で外れ値にロバストな分位クリップ（例: 1%/99%）。
+
+---
+
+### エージェント（regions/macro/optimizer/chair）
+- `RegionAgent`
+  - 取得失敗時のダミー生成フォールバックをユニットテスト化。`evidence` の乱数依存をseed固定。
+- `MacroAgent`
+  - CSV重み取り込み時の検証（負値clip、対象地域での正規化）。
+- `Chair`
+  - `use_ai=True` 経路のモックテスト、`is_openai_configured()` の分岐を明示。
+  - レポートにリスク設定と主要KPI表（地域ボラ/相関）を追記。
+
+---
+
+### CLI/アプリ（`src/app.py`）
+- `run` に以下オプション（デフォルトは後方互換）:
+  - `--risk-aversion`, `--target-vol`, `--target {min_vol,max_return}`
+  - `--macro-csv`（既存）、`--verbose/-v`（進捗可視化）
+- 生成アーティファクトの存在確認とパス出力（既存OK）。
+- Typer 用 `CliRunner` で E2E 最小ケースを追加。
+
+---
+
+### テスト戦略（TDD）
+- ユニット
+  - `optimizer_tool`: 境界（position/cash/region/vol）と目的関数切替。
+  - `features`: モメンタム/出来高トレンド/NaN境界。
+  - `news`: yfinance差異（headline/link/providerPublishTime）をモックで吸収。
+- 統合
+  - `RegionAgent.run` → `optimize_portfolio` → `build_report` までの薄い統合。
+  - `RiskAgent.run` の複数地域パネル結合（outer join）と空入力時挙動。
+- CLI/E2E
+  - `app.run` で `artifacts/` に `candidates_*`, `growth_*`, `portfolio_*`, `risk_*`, `report_*.md` が生成されること。
+- 安定化
+  - 乱数seed固定、ネットワークはモック、画像生成は `importorskip`。
+
+---
+
+### DevEx / CI / 品質
+- pre-commit: `ruff`, `black`, `mypy` を導入。`requirements.txt` は上限ピンまたは `uv pip compile` を活用。
+- GitHub Actions: `pytest -q`, lint, 依存キャッシュ、Artifacts 保存。
+- `.gitignore`: `._*`, `.DS_Store`, `artifacts/*.png`, `artifacts/*.md`（必要に応じ）を整理。
+- Makefile: 失敗時にエラー終了、`test`, `lint`, `format` ターゲット追加。
+
+---
+
+### 観測可能性・再現性
+- すべての `portfolio_*.json` と `report_*.md` に以下メタを追記/記録：
+  - `as_of`, `regions`, `position_limit`, `region_limits`, `cash_bounds`, `risk_aversion`, `target_vol`, `target`。
+  - 実行 `git` の `commit`/`branch`、価格データの期間（最古/最新日付）。
+- ログ: 構造化（tsv/json）、WARNING 以上で外部依存の失敗を記録（ティッカー・試行回数）。
+
+---
+
+### セキュリティ/法令・注意
+- README とレポートに「投資助言ではない」明記（既存維持）。
+- 外部APIの利用規約順守、PII 不扱いの確認、OpenAI キー漏えい防止（`.env` + CI secret）。
+
+---
+
+### 次のアクション（小さなPRに分割）
+1) `optimizer_tool`/`agents/optimizer.py`/`app.run` に `risk_aversion`/`target_vol` を導入（単体・統合テスト含む）。
+2) レポートにリスク設定サマリーとKPI表を追記（図は既存関数を活用）。
+3) `features` テクニカル/ニュース/ファンダの境界テスト追加とロバスト化。
+4) CLI/E2E 最小ケースを Typer で追加し、CI へ組込み。
+5) pre-commit/ruff/black/mypy と `.gitignore` 更新、Makefile に `test/lint` 追加。
+
+

--- a/src/agents/regions.py
+++ b/src/agents/regions.py
@@ -86,6 +86,14 @@ class RegionAgent:
                     "news": float(row.get("score_news", 0.0)),
                     "growth": float(row.get("score_growth", 0.0)),
                 }
+                
+                # 成長スコアの詳細表示を追加
+                growth_breakdown = {
+                    "revenue_cagr": float(row.get("growth_revenue_cagr", 0.5)),
+                    "eps_growth": float(row.get("growth_eps_growth", 0.5)),
+                    "overall": float(row.get("score_growth", 0.0)),
+                }
+                
                 if is_openai_configured():
                     thesis, risks = generate_thesis_and_risks(ticker, name, self.name, features)
                 else:
@@ -100,6 +108,7 @@ class RegionAgent:
                         "name": name,
                         "score_overall": float(row.get("score_overall", 0.0)),
                         "score_breakdown": features,
+                        "growth_breakdown": growth_breakdown,
                         "thesis": thesis,
                         "risks": risks,
                         "evidence": evidence,

--- a/src/scoring/features.py
+++ b/src/scoring/features.py
@@ -98,11 +98,13 @@ def merge_fundamentals(features_df: pd.DataFrame, fundamentals_df: pd.DataFrame)
         df["fundamental_fcf_margin"] = (
             df["fcf_margin"].astype(float, errors="ignore").fillna(df["fundamental_fcf_margin"])
         )
-    # 成長指標
+    # 成長指標（正規化を適用）
     if "revenue_cagr" in df.columns:
-        df["growth_revenue_cagr"] = df["revenue_cagr"].astype(float, errors="ignore")
+        from .normalize import normalize_growth_rate
+        df["growth_revenue_cagr"] = df["revenue_cagr"].astype(float, errors="ignore").apply(normalize_growth_rate)
     if "eps_growth" in df.columns:
-        df["growth_eps_growth"] = df["eps_growth"].astype(float, errors="ignore")
+        from .normalize import normalize_growth_rate
+        df["growth_eps_growth"] = df["eps_growth"].astype(float, errors="ignore").apply(normalize_growth_rate)
     return df
 
 

--- a/src/scoring/normalize.py
+++ b/src/scoring/normalize.py
@@ -15,6 +15,28 @@ def _min_max(col: pd.Series) -> pd.Series:
     return scaled.clip(0.0, 1.0)
 
 
+def normalize_growth_rate(rate: float) -> float:
+    """成長率を0-1の範囲に正規化（極端な値を制限）
+    
+    Args:
+        rate: 成長率（例: 0.25 = 25%成長）
+    
+    Returns:
+        正規化された値（0-1）
+    """
+    if pd.isna(rate):
+        return 0.5
+    
+    # 極端な成長率の処理
+    if rate > 2.0:  # 200%以上の成長率
+        return 1.0
+    elif rate < -0.5:  # -50%以下の成長率
+        return 0.0
+    else:
+        # -50% to +200% → 0 to 1
+        return (rate + 0.5) / 2.5
+
+
 def normalize_features(df: pd.DataFrame) -> pd.DataFrame:
     df = df.copy()
     for col in df.columns:

--- a/src/scoring/scoring.py
+++ b/src/scoring/scoring.py
@@ -6,18 +6,18 @@ import pandas as pd
 
 @dataclass
 class ScoreWeights:
-    fundamental: float = 0.4
-    technical: float = 0.35
-    quality: float = 0.15
-    news: float = 0.10
-    growth: float = 0.0  # 既存スコアに影響しない初期値（必要に応じて引き上げ）
+    fundamental: float = 0.35  # 0.4 → 0.35
+    technical: float = 0.30    # 0.35 → 0.30
+    quality: float = 0.15      # 変更なし
+    news: float = 0.10         # 変更なし
+    growth: float = 0.10       # 0.0 → 0.10
 
 
 def score_candidates(df_features: pd.DataFrame, weights: ScoreWeights) -> pd.DataFrame:
     """特徴量を合成してスコアリング。
 
     入力: normalize済みの特徴量
-    出力: score_fundamental, score_technical, score_quality, score_news, score_overall
+    出力: score_fundamental, score_technical, score_quality, score_news, score_growth, score_overall
     """
     df = df_features.copy()
     df["score_fundamental"] = (

--- a/tests/unit/test_features_merge_fundamentals_growth.py
+++ b/tests/unit/test_features_merge_fundamentals_growth.py
@@ -1,6 +1,7 @@
 import pandas as pd
 
 from src.scoring.features import merge_fundamentals
+from src.scoring.normalize import normalize_growth_rate
 
 
 def test_merge_fundamentals_adds_growth_columns():
@@ -26,7 +27,10 @@ def test_merge_fundamentals_adds_growth_columns():
     row = out.iloc[0]
     assert abs(row["fundamental_roic"] - 0.2) < 1e-9
     assert abs(row["fundamental_fcf_margin"] - 0.1) < 1e-9
-    assert abs(row["growth_revenue_cagr"] - 0.3) < 1e-9
-    assert abs(row["growth_eps_growth"] - 0.4) < 1e-9
+    # 成長率は正規化される
+    expected_revenue_cagr = normalize_growth_rate(0.3)
+    expected_eps_growth = normalize_growth_rate(0.4)
+    assert abs(row["growth_revenue_cagr"] - expected_revenue_cagr) < 1e-9
+    assert abs(row["growth_eps_growth"] - expected_eps_growth) < 1e-9
 
 

--- a/tests/unit/test_scoring.py
+++ b/tests/unit/test_scoring.py
@@ -1,34 +1,57 @@
 import numpy as np
 import pandas as pd
+import pytest
 
-from src.scoring.normalize import normalize_features
+from src.scoring.normalize import normalize_features, normalize_growth_rate
 from src.scoring.scoring import ScoreWeights, score_candidates
 
 
 def test_normalize_features_handles_constant_and_nan():
     df = pd.DataFrame({
-        "ticker": ["A", "B"],
-        "name": ["A", "B"],
-        "x": [1.0, 1.0],
-        "y": [np.nan, 2.0],
+        "ticker": ["A", "B", "C"],
+        "name": ["A", "B", "C"],
+        "value": [1.0, 1.0, 1.0],  # 定数
+        "nan_value": [1.0, float("nan"), 2.0],  # NaN含む
     })
-    out = normalize_features(df)
-    assert ((out["x"] >= 0) & (out["x"] <= 1)).all()
-    assert ((out["y"] >= 0) & (out["y"] <= 1)).all()
+    result = normalize_features(df)
+    assert result["value"].iloc[0] == 0.5  # 定数は0.5
+    assert result["nan_value"].iloc[1] == 0.5  # NaNは中央値で補完
 
 
 def test_score_candidates_basic():
     df = pd.DataFrame({
         "ticker": ["A", "B"],
-        "name": ["A", "B"],
-        "fundamental_roic": [0.2, 0.8],
-        "fundamental_fcf_margin": [0.3, 0.7],
-        "technical_mom_12m": [0.5, 0.6],
-        "technical_volume_trend": [0.4, 0.5],
-        "quality_dilution": [0.6, 0.4],
-        "news_signal": [0.5, 0.5],
+        "fundamental_roic": [0.8, 0.2],
+        "fundamental_fcf_margin": [0.9, 0.1],
+        "technical_mom_12m": [0.7, 0.3],
+        "technical_volume_trend": [0.6, 0.4],
+        "quality_dilution": [0.5, 0.5],
+        "news_signal": [0.4, 0.6],
+        "growth_revenue_cagr": [0.3, 0.7],
+        "growth_eps_growth": [0.2, 0.8],
     })
-    out = score_candidates(df, ScoreWeights())
-    assert "score_overall" in out.columns
-    assert out.shape[0] == 2
+    weights = ScoreWeights()
+    result = score_candidates(df, weights)
+    
+    # 成長スコアが有効になっていることを確認
+    assert "score_growth" in result.columns
+    assert result["score_growth"].iloc[0] == 0.25  # (0.3 + 0.2) / 2
+    assert result["score_growth"].iloc[1] == 0.75  # (0.7 + 0.8) / 2
+    
+    # 総合スコアに成長スコアが反映されていることを確認
+    assert "score_overall" in result.columns
+
+
+def test_normalize_growth_rate():
+    # 正常な成長率
+    assert abs(normalize_growth_rate(0.0) - 0.2) < 1e-9  # 0% → 0.2
+    assert abs(normalize_growth_rate(0.25) - 0.3) < 1e-9  # 25% → 0.3
+    assert abs(normalize_growth_rate(0.5) - 0.4) < 1e-9   # 50% → 0.4
+    
+    # 極端な成長率の制限
+    assert normalize_growth_rate(3.0) == 1.0  # 300% → 1.0
+    assert normalize_growth_rate(-0.6) == 0.0  # -60% → 0.0
+    
+    # NaN処理
+    assert normalize_growth_rate(float("nan")) == 0.5
 


### PR DESCRIPTION
## 変更内容

### 🎯 成長スコアの有効化
- **ScoreWeights**の重みをからに変更
- 他の重みを調整して合計が1.0になるように修正：
  - : 0.4 → 0.35
  - : 0.35 → 0.30
  - : 0.15（変更なし）
  - : 0.10（変更なし）
  - : 0.0 → 0.10

### 📊 成長スコアの詳細表示
- **RegionAgent**の出力にを追加
- 売上成長率（）とEPS成長率（）の詳細を表示
- 成長スコアの構成要素を明確化

### 🔧 成長率の正規化改善
- **normalize_growth_rate**関数を追加
- 極端な成長率を制限：
  - -50%以下 → 0.0
  - +200%以上 → 1.0
  - その他 → 線形正規化
- NaN値は0.5で補完

### 🧪 テストの更新・追加
- 成長率正規化のテストを追加
- 既存テストを新しい重み設定に対応
- 成長スコアの有効化を確認するテストを追加

## 効果
- EPS成長率が総合スコアに反映されるようになりました
- 成長スコアの詳細が出力に含まれ、分析が容易になりました
- 極端な成長率の影響を抑制し、より安定したスコアリングが可能になりました

## テスト結果
- 全テストがパス
- 実際の実行で成長スコアが正しく計算・表示されることを確認