### PR TITLE
feat(optimizer): notesに最適化設定を含める

### DIFF
--- a/src/agents/optimizer.py
+++ b/src/agents/optimizer.py
@@ -106,13 +106,20 @@ def optimize_portfolio(
     ]
     cash_weight = round(max(0.0, 1.0 - sum(x["weight"] for x in weights)), 6)
 
+    # notesに設定を反映
+    notes_settings = (
+        f"target={cfg.target} risk_aversion={cfg.risk_aversion} "
+        f"target_vol={cfg.target_vol if cfg.target_vol is not None else 'None'}"
+    )
+    notes = f"P0 mean-variance ({note_flag}); {notes_settings}" if note_flag else f"P0 mean-variance; {notes_settings}"
+
     return {
         "as_of": as_of,
         "region_limits": region_limits,
         "position_limit": position_limit,
         "weights": weights,
         "cash_weight": cash_weight,
-        "notes": f"P0 mean-variance ({note_flag})",
+        "notes": notes,
     }
 
 

--- a/tests/unit/test_optimizer_portfolio_comprehensive.py
+++ b/tests/unit/test_optimizer_portfolio_comprehensive.py
@@ -215,3 +215,33 @@ class TestOptimizerPortfolioComprehensive:
         # 地域制限を遵守していることを確認
         assert jp_total <= 0.10
         assert us_total <= 0.20
+
+
+def test_optimize_portfolio_notes_contains_settings():
+    candidates_all = [
+        {"region": "US", "candidates": [
+            {"ticker": "AAPL", "score_overall": 0.9},
+            {"ticker": "MSFT", "score_overall": 0.8},
+            {"ticker": "GOOG", "score_overall": 0.7},
+        ]}
+    ]
+
+    constraints = {
+        "region_limits": {"US": 0.5},
+        "position_limit": 0.2,
+        "cash_min": 0.0,
+        "cash_max": 0.1,
+        "as_of": "2025-09-01",
+        "risk_aversion": 3.0,
+        "target_vol": 0.18,
+        "target": "min_vol",
+    }
+
+    result = optimize_portfolio(candidates_all, constraints, prices_df=None)
+
+    assert isinstance(result.get("notes"), str)
+    notes = result["notes"]
+    # 設定の一部がnotes文字列に含まれていること
+    assert "risk_aversion=3.0" in notes
+    assert "target_vol=0.18" in notes
+    assert "target=min_vol" in notes


### PR DESCRIPTION
P0小粒: optimize_portfolioのnotesに\n- target\n- risk_aversion\n- target_vol\nを含めるように変更。\nテスト: 追加ユニットテストを含め68 passed。\n背景: doc/plan.md のP0(観測可能性/再現性)に基づく。